### PR TITLE
KafkaBrokerApp#operational should not send data to avoid protocol eror.

### DIFF
--- a/trivup/apps/KafkaBrokerApp.py
+++ b/trivup/apps/KafkaBrokerApp.py
@@ -2,6 +2,7 @@ from trivup import trivup
 from trivup.apps.KerberosKdcApp import KerberosKdcApp
 
 import os
+import socket
 import time
 
 
@@ -162,8 +163,8 @@ class KafkaBrokerApp (trivup.App):
 
     def operational (self):
         self.dbg('Checking if operational')
-        return os.system('(echo anything | nc %s) 2>/dev/null' %
-                         ' '.join(self.get('address').split(':'))) == 0
+        addr, port = self.get('address').split(':')
+        return socket.socket(socket.AF_INET, socket.SOCK_STREAM).connect_ex((addr, int(port))) == 0
 
 
     def deploy (self):

--- a/trivup/apps/KafkaBrokerApp.py
+++ b/trivup/apps/KafkaBrokerApp.py
@@ -1,6 +1,7 @@
 from trivup import trivup
 from trivup.apps.KerberosKdcApp import KerberosKdcApp
 
+import contextlib
 import os
 import socket
 import time
@@ -164,8 +165,8 @@ class KafkaBrokerApp (trivup.App):
     def operational (self):
         self.dbg('Checking if operational')
         addr, port = self.get('address').split(':')
-        return socket.socket(socket.AF_INET, socket.SOCK_STREAM).connect_ex((addr, int(port))) == 0
-
+        with contextlib.closing(socket(socket.AF_INET, socket.SOCK_STREAM)) as s:
+            return s.connect_ex((addr, int(port))) == 0
 
     def deploy (self):
         destdir = os.path.join(self.cluster.mkpath(self.__class__.__name__), 'kafka', self.get('version'))


### PR DESCRIPTION
Sending data to broker by "echo anything | nc ..." caused broker error and connection reset which resulted in error exit of nc. KafkaBrokerApp#operational always return false due to this.

```
[2017-07-28 02:05:04,735] WARN Unexpected error from /127.0.0.1; closing connection (org.apache.kafka.common.network.Selector)
org.apache.kafka.common.network.InvalidReceiveException: Invalid receive (size = 1634630004 larger than 104857600)
        at org.apache.kafka.common.network.NetworkReceive.readFromReadableChannel(NetworkReceive.java:91)
        at org.apache.kafka.common.network.NetworkReceive.readFrom(NetworkReceive.java:71)
        at org.apache.kafka.common.network.KafkaChannel.receive(KafkaChannel.java:153)
        at org.apache.kafka.common.network.KafkaChannel.read(KafkaChannel.java:134)
        at org.apache.kafka.common.network.Selector.poll(Selector.java:286)
        at kafka.network.Processor.run(SocketServer.scala:413)
        at java.lang.Thread.run(Thread.java:748)
```
How about just checking the broker port is open?
