### PR TITLE
add Quick start instructions and generalize $HOME path

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,16 @@ broker versions.
 
 
 See [tests/usecase.py](tests/usecase.py) for a small showcase.
+
+## Quick start on Ubuntu
+
+Install Java 8 (follow Apache Kafka instructions, or just get Oracle Java from webupd8team)
+
+```
+$ java -version
+$ git clone git@github.com:edenhill/trivup.git
+$ cd trivup
+$ PYTHONPATH=$PWD ./tests/ssl.py
+$ PYTHONPATH=$PWD ./tests/usecase.py
+
+```

--- a/tests/usecase.py
+++ b/tests/usecase.py
@@ -6,19 +6,25 @@ from trivup.apps.KafkaBrokerApp import KafkaBrokerApp
 
 import subprocess
 import time
+import os
 
+# Directory for cloning Apache Kafka sources to.
+# It will only be used if 'version' is not specified.
+# Otherwise Apache Kafka binary distrubution will be downloaded to
+# a cluster data dir ( trivup/tmp/TestCluster/KafkaBrokerApp/kafka/conf['version'] )
+kafka_dir=os.path.join(os.path.expanduser('~'), "src", "kafka")
 
 if __name__ == '__main__':
     cluster = Cluster('TestCluster', 'tmp')
 
     # One ZK
-    zk1 = ZookeeperApp(cluster, bin_path='/home/maglun/src/kafka/bin/zookeeper-server-start.sh')
+    zk1 = ZookeeperApp(cluster, bin_path=os.path.join(kafka_dir, '/bin/zookeeper-server-start.sh'))
 
-    # Two brokers
-    conf = {'replication_factor': 3, 'num_partitions': 4}
-    broker1 = KafkaBrokerApp(cluster, conf, kafka_path='/home/maglun/src/kafka')
-    broker2 = KafkaBrokerApp(cluster, conf, kafka_path='/home/maglun/src/kafka')
-    broker3 = KafkaBrokerApp(cluster, conf, kafka_path='/home/maglun/src/kafka')
+    # Multiple Kafka brokers
+    conf = {'version': '2.2.0', 'replication_factor': 3, 'num_partitions': 4, 'kafka_path': kafka_dir}
+    broker1 = KafkaBrokerApp(cluster, conf)
+    broker2 = KafkaBrokerApp(cluster, conf)
+    broker3 = KafkaBrokerApp(cluster, conf)
     bootstrap_servers = ','.join(cluster.get_all('address','',KafkaBrokerApp))
 
     print('# Deploying cluster')
@@ -32,7 +38,7 @@ if __name__ == '__main__':
     if not cluster.wait_operational(30):
         print('# Cluster did not go operational: letting you troubleshoot in shell')
     print('# Connect to cluster with bootstrap.servers %s' % bootstrap_servers)
-        
+
     print('\033[32mCluster started.. Executing interactive shell, exit to stop cluster\033[0m')
     subprocess.call("bash", shell=True)
 

--- a/tests/usecase.py
+++ b/tests/usecase.py
@@ -21,7 +21,7 @@ if __name__ == '__main__':
     zk1 = ZookeeperApp(cluster, bin_path=os.path.join(kafka_dir, '/bin/zookeeper-server-start.sh'))
 
     # Multiple Kafka brokers
-    conf = {'version': '2.2.0', 'replication_factor': 3, 'num_partitions': 4, 'kafka_path': kafka_dir}
+    conf = {'version': '2.2.0', 'replication_factor': 3, 'num_partitions': 4}
     broker1 = KafkaBrokerApp(cluster, conf)
     broker2 = KafkaBrokerApp(cluster, conf)
     broker3 = KafkaBrokerApp(cluster, conf)


### PR DESCRIPTION
With these changes, I'm able to start my cluster.

Previously there was an error about the unknown argument 'kafka_path' in KafkaBrokerApp constructor.

The only thing I changed: by default, it will start with Kafka broker 2.2.0 (binary distribution) instead of cloning and building Kafka sources. I hope it will not disrupt the way you are used to working with this testing framework. But on the other hand, it will help new users start quickly.
