### PR TITLE
Add with_ca and through_intermediate arguments to create_cert

### DIFF
--- a/tests/ssl.py
+++ b/tests/ssl.py
@@ -11,9 +11,19 @@ if __name__ == '__main__':
     ssl = SslApp(cluster)
 
     a = ssl.create_keystore('mybroker')
-    print('created keystore: %s' % a)
+    print('created keystore: %s' % (a,))
 
     r = ssl.create_cert('myclient')
+    print('created key: %s' % r)
+
+    r = ssl.create_cert('selfsigned_myclient', with_ca=False)
+    print('created key: %s' % r)
+
+    r = ssl.create_cert('intermediate_myclient', through_intermediate=True)
+    print('created key: %s' % r)
+
+    r = ssl.create_cert('selfsigned_intermediate_myclient',
+                        with_ca=False, through_intermediate=True)
     print('created key: %s' % r)
 
     cluster.cleanup(keeptypes=[])


### PR DESCRIPTION
Lets you generate SSL certificates that are actually signed through an intermediate that's signed through the CA, and that actually is not signed by the CA at all.

Using it should simply be a matter of passing `with_ca=False` (to get the selfsigned ones), or `through_intermediate=True` to get it signed by an intermediate. In the latter case, the returned hash will also have `intermediate_priv` and `intermediate_pub` elements in it now.