### PR TITLE
Add scope validation for OIDC

### DIFF
--- a/trivup/apps/OauthbearerOIDCApp.py
+++ b/trivup/apps/OauthbearerOIDCApp.py
@@ -38,7 +38,7 @@ import json
 import argparse
 import requests
 
-VALID_SCOPE = ['test', 'test-scope', 'api://1234-abcd/.default']
+VALID_SCOPES = ['test', 'test-scope', 'api://1234-abcd/.default']
 
 class WebServerHandler(BaseHTTPRequestHandler):
     def __init__(self):
@@ -155,10 +155,10 @@ class WebServerHandler(BaseHTTPRequestHandler):
 
         index_begin_scope = len("grant_type=client_credentials&scope=")
         scope = post_data[index_begin_scope:]
-        if scope not in VALID_SCOPE:
+        if scope not in VALID_SCOPES:
             self.send_error(400,
-                            'Invalid scope, scope should be "test",'
-                            '"test-scope" or "api://1234-abcd/.default"')
+                            'Invalid scope, scope should be one of %s' %
+                            VALID_SCOPES)
             return False
 
         return True
@@ -186,15 +186,15 @@ class WebServerHandler(BaseHTTPRequestHandler):
         content_length = int(self.headers['Content-Length'])
         post_data = self.rfile.read(content_length)
 
-        if not self.valid_post_data(post_data):
-            return
-
         if self.headers.get('Authorization', None) is None:
             self.send_error(400, 'Authorization field is required')
             return
 
         if self.headers.get('Accept', None) != "application/json":
             self.send_error(400, 'Accept field should be "application/json"')
+            return
+
+        if not self.valid_post_data(post_data):
             return
 
         self.send_response(200)

--- a/trivup/apps/OauthbearerOIDCApp.py
+++ b/trivup/apps/OauthbearerOIDCApp.py
@@ -38,6 +38,7 @@ import json
 import argparse
 import requests
 
+VALID_SCOPE = ['test', 'test-scope', 'api://1234-abcd/.default']
 
 class WebServerHandler(BaseHTTPRequestHandler):
     def __init__(self):
@@ -134,6 +135,34 @@ class WebServerHandler(BaseHTTPRequestHandler):
         public_key = key.export_public()
         return (public_key, key)
 
+    def valid_post_data(self, post_data):
+        if post_data is None:
+            self.send_error(400,
+                            'grant_type=client_credentials and scope \
+                             fields are required in data')
+            return False
+
+        post_data = post_data.decode("utf-8")
+
+        if post_data == "grant_type=client_credentials":
+            return True
+
+        if not post_data.startswith("grant_type=client_credentials&scope="):
+            self.send_error(400,
+                            'format of data should be grant_type='
+                            'client_credentials&scope=scope_value')
+            return False
+
+        index_begin_scope = len("grant_type=client_credentials&scope=")
+        scope = post_data[index_begin_scope:]
+        if scope not in VALID_SCOPE:
+            self.send_error(400,
+                            'Invalid scope, scope should be "test",'
+                            '"test-scope" or "api://1234-abcd/.default"')
+            return False
+
+        return True
+
     def generate_valid_token_for_client(self):
         """
         Example usage:
@@ -157,18 +186,15 @@ class WebServerHandler(BaseHTTPRequestHandler):
         content_length = int(self.headers['Content-Length'])
         post_data = self.rfile.read(content_length)
 
+        if not self.valid_post_data(post_data):
+            return
+
         if self.headers.get('Authorization', None) is None:
             self.send_error(400, 'Authorization field is required')
             return
 
         if self.headers.get('Accept', None) != "application/json":
             self.send_error(400, 'Accept field should be "application/json"')
-            return
-
-        if post_data is None:
-            self.send_error(400,
-                            'grant_type=client_credentials and scope \
-                             fields are required in data')
             return
 
         self.send_response(200)


### PR DESCRIPTION
Since the scope is an optional field, the `-d` for the token provider should be `client_credentials` or `client_credentials&scope=scope_value`. 
Add the validation check for `-d` to make sure the format of data is correct and also the scope value is valid.

The accepted scopes are 'test', 'test-scope', 'api://1234-abcd/.default'.

1. Test with empty scope
Printed post data : `post grant_type=client_credentials`
```
[0126_oauthbearer_oidc       / 29.947s] ================= Test 0126_oauthbearer_oidc PASSED =================
[<MAIN>                      / 30.097s] ALL-TESTS: duration 30097.332ms
TEST 20220725144356 (bare, scenario default) SUMMARY
#==================================================================#
| <MAIN>                                   |     PASSED |  30.097s |
| 0126_oauthbearer_oidc                    |     PASSED |  29.947s |
#==================================================================#
[<MAIN>                      / 30.099s] 0 thread(s) in use by librdkafka
[<MAIN>                      / 30.099s] 
============== ALL TESTS PASSED ==============
```

2. Test with scope 'api://1234-abcd/.default'
Printed post data: `post grant_type=client_credentials&scope=api://1234-abcd/.default`
```
[0126_oauthbearer_oidc       / 31.188s] ================= Test 0126_oauthbearer_oidc PASSED =================
[<MAIN>                      / 32.100s] ALL-TESTS: duration 32099.939ms
TEST 20220725144129 (bare, scenario default) SUMMARY
#==================================================================#
| <MAIN>                                   |     PASSED |  32.100s |
| 0126_oauthbearer_oidc                    |     PASSED |  31.188s |
#==================================================================#
[<MAIN>                      / 32.102s] 0 thread(s) in use by librdkafka
[<MAIN>                      / 32.102s] 
============== ALL TESTS PASSED ==============
###
###  ./test-runner in bare mode PASSED! ###
###
```

3. Test with unaccepted scope `api://1234-abcd/.defaultaaa`
Printed scope: `post grant_type=client_credentials&scope=api://1234-abcd/.defaultaaa`
```
%3|1658785362.772|OIDC|0126_oauthbearer_oidc#producer-1| [thrd:background]: Failed to retrieve OIDC token from "http://localhost:50397/retrieve": <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN"
        "http://www.w3.org/TR/html4/strict.dtd">
<html>
    <head>
        <meta http-equiv="Content-Type" content="text/html;charset=utf-8">
        <title>Error response</title>
    </head>
    <body>
        <h1>Error response</h1>
        <p>Error code: 400</p>
        <p>Message: Invalid scope, scope should be "test","test-scope" or "api://1234-abcd/.default".</p>
        <p>Error code explanation: 400 - Bad request syntax or unsupported method.</p>
    </body>
</html>
 (400)
[<MAIN>                      /  1.004s] 1 test(s) running: 0126_oauthbearer_oidc
[<MAIN>                      /  2.009s] 1 test(s) running: 0126_oauthbearer_oidc
[<MAIN>                      /  3.014s] 1 test(s) running: 0126_oauthbearer_oidc
[<MAIN>                      /  4.017s] 1 test(s) running: 0126_oauthbearer_oidc
[<MAIN>                      /  5.019s] 1 test(s) running: 0126_oauthbearer_oidc
[<MAIN>                      /  6.020s] 1 test(s) running: 0126_oauthbearer_oidc
^CExiting tests, waiting for running tests to finish.
[<MAIN>                      /  6.577s] ALL-TESTS: duration 6577.386ms
TEST 20220725144249 (bare, scenario default) SUMMARY
#==================================================================#
| <MAIN>                                   |     PASSED |   6.578s |
| 0126_oauthbearer_oidc                    |    RUNNING |   6.578s |
#==================================================================#
[<MAIN>                      /  6.578s] 6 thread(s) in use by librdkafka, waiting...
[<MAIN>                      /  7.583s] 6 thread(s) in use by librdkafka
[<MAIN>                      /  7.584s] TEST FAILURE
```
