### PR TITLE
Fix minor bugs

### DIFF
--- a/trivup/apps/OauthbearerOIDCApp.py
+++ b/trivup/apps/OauthbearerOIDCApp.py
@@ -173,7 +173,7 @@ class WebServerHandler(BaseHTTPRequestHandler):
         -H "Content-Type: application/x-www-form-urlencoded" \
         -H "Authorization: Basic LW4gYWJjMTIzOlMzY3IzdCEK \
             (base64 string generated from CLIENT_ID:CLIENT_SECRET)"
-        -d "grant_type=client_credentials,scope=test-scope"
+        -d "grant_type=client_credentials&scope=test-scope"
         """
         if self.headers.get('Content-Length', None) is None:
             self.send_error(400, 'Content-Length field is required')

--- a/trivup/clusters/KafkaCluster.py
+++ b/trivup/clusters/KafkaCluster.py
@@ -250,7 +250,7 @@ class KafkaCluster(object):
                     break
 
             elif self.sasl_mechanism == 'OAUTHBEARER':
-                if self.oidc is not None:
+                if hasattr(self, 'oidc'):
                     self._client_conf['sasl.oauthbearer.method'] = 'OIDC'
                     self._client_conf['sasl.oauthbearer.token.endpoint.url'] = self.oidc.get('valid_url')  # noqa: E501
                     self._client_conf['sasl.oauthbearer.client.id'] = '123'

--- a/trivup/clusters/KafkaCluster.py
+++ b/trivup/clusters/KafkaCluster.py
@@ -126,6 +126,8 @@ class KafkaCluster(object):
                 self.sasl_mechanism = 'OAUTHBEARER'
             elif self.sasl_mechanism.upper() != 'OAUTHBEARER':
                 raise RuntimeError(f"OIDC requires sasl.mechanism OAUTHBEARER, not '{self.sasl_mechanism}'")
+        else:
+            self.oidc = None
 
         # Generate SSL certs if enabled
         if bool(self.conf.get('with_ssl')):
@@ -250,7 +252,7 @@ class KafkaCluster(object):
                     break
 
             elif self.sasl_mechanism == 'OAUTHBEARER':
-                if hasattr(self, 'oidc'):
+                if self.oidc is not None:
                     self._client_conf['sasl.oauthbearer.method'] = 'OIDC'
                     self._client_conf['sasl.oauthbearer.token.endpoint.url'] = self.oidc.get('valid_url')  # noqa: E501
                     self._client_conf['sasl.oauthbearer.client.id'] = '123'


### PR DESCRIPTION
Fix bugs.

1. While setting up a cluster using OAuth authentication but without OIDC, `oidc` is not present in the `self` instance causing the failure.
2. Fix the curl command for obtaining the token when using OIDC.

Tested both of them while running https://github.com/confluentinc/confluent-kafka-dotnet/pull/1947/files