### PR TITLE
Add option to use custom schema registry image for kafkacluster

### DIFF
--- a/trivup/clusters/KafkaCluster.py
+++ b/trivup/clusters/KafkaCluster.py
@@ -197,7 +197,7 @@ class KafkaCluster(object):
         # Create SchemaRegistry if enabled
         if bool(self.conf.get('with_sr', False)):
             self.sr = SchemaRegistryApp(
-                self.cluster, {'version': self.conf.get('cp_version')})
+                self.cluster, {'version': self.conf.get('cp_version'), 'image': self.conf.get('sr_image')})
             self.env['SR_URL'] = self.sr.get('url')
 
         # Create librdkafka client configuration


### PR DESCRIPTION
I want the schema registry image to be pulled from a custom repository and not from docker hub.
So I added an option to allow kafkacluster to use a custom schema registry image.